### PR TITLE
Cow Energy Work

### DIFF
--- a/src/main/java/com/geneticselection/mobs/Cows/CustomCowEntity.java
+++ b/src/main/java/com/geneticselection/mobs/Cows/CustomCowEntity.java
@@ -19,6 +19,8 @@ import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
+import net.minecraft.block.Blocks;
+
 
 import java.util.Optional;
 
@@ -104,8 +106,32 @@ public class CustomCowEntity extends CowEntity {
     @Override
     public ActionResult interactMob(PlayerEntity player, Hand hand) {
         ItemStack itemStack = player.getStackInHand(hand);
+        ItemStack offHandStack = player.getOffHandStack();  // Get the item in the offhand
 
-        if (itemStack.isOf(Items.BUCKET) && !this.isBaby()) {
+        // Check if the item in the main hand is wheat
+        if (itemStack.isOf(Items.WHEAT)) {
+            // Prevent breeding if the cow's energy level is below the threshold (e.g., 20)
+            if (ELvl < 20.0) {
+                player.sendMessage(Text.of("This cow cannot breed because it has low energy."), true);
+                return ActionResult.FAIL;  // Prevent interaction with wheat for breeding
+            }
+            // Proceed with the usual interaction for breeding if energy is sufficient
+            return super.interactMob(player, hand);
+        }
+
+        // Check if the item in the offhand is wheat
+        else if (offHandStack.isOf(Items.WHEAT)) {
+            // Prevent breeding if the cow's energy level is below the threshold (30)
+            if (ELvl < 30.0) {
+                player.sendMessage(Text.of("This cow cannot breed because it has low energy."), true);
+                return ActionResult.FAIL;  // Prevent interaction with offhand wheat for breeding
+            }
+            // Proceed with the usual interaction for breeding if energy is sufficient
+            return super.interactMob(player, Hand.OFF_HAND);
+        }
+
+        // Handle other interactions (e.g., milking with a bucket)
+        else if (itemStack.isOf(Items.BUCKET) && !this.isBaby()) {
             if (!this.getWorld().isClient) {
                 long currentTime = this.getWorld().getTime();
                 if (currentTime - lastMilkTime >= milkingCooldown) {
@@ -122,7 +148,7 @@ public class CustomCowEntity extends CowEntity {
             return ActionResult.CONSUME;
         }
         else if (itemStack.isEmpty()) { // Check if the hand is empty
-            // Only display the stats on the server side to avoid duplication
+            // Update description or other actions as before
             if (!this.getWorld().isClient)
                 updateDescription(this);
 
@@ -133,27 +159,39 @@ public class CustomCowEntity extends CowEntity {
         }
     }
 
+
     @Override
     protected void applyDamage(DamageSource source, float amount) {
         super.applyDamage(source, amount);
 
+        // Dynamically adjust movement speed based on current energy
+        this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED)
+                .setBaseValue(Speed * (ELvl / 100.0));
+
         if (!this.getWorld().isClient)
             updateDescription(this);
-
     }
 
     @Override
     public void onDeath(DamageSource source) {
-        super.onDeath(source);
+        // If the cow is a baby, don't drop any items
+        if (this.isBaby()) {
+            return;
+        }
+        // If energy is zero, drop bones instead of meat or leather
+        if (ELvl <= 0.0) {
+            // Ensure bones are dropped
+            this.dropStack(new ItemStack(Items.BONE, 1)); // Drop one bone
+        } else {
+            // Normal death drops (meat and leather)
+            super.onDeath(source);
+            if (!this.getWorld().isClient) {
+                int scaledMeatAmount = (int) ((MinMeat + this.getWorld().random.nextInt((int) (MaxMeat - MinMeat) + 1)) * (ELvl / 100.0));
+                this.dropStack(new ItemStack(Items.BEEF, Math.max(0, scaledMeatAmount))); // Ensure no negative values
 
-        if (!this.getWorld().isClient) {
-            // Calculate the amount of meat to drop between MinMeat and MaxMeat
-            int meatAmount = (int) (MinMeat + this.getWorld().random.nextInt(((int)(MaxMeat - MinMeat)) + 1));
-            this.dropStack(new ItemStack(Items.BEEF, meatAmount));
-
-            // Calculate the amount of leather to drop between MinLeather and MaxLeather
-            int leatherAmount = (int)(MinLeather + this.getWorld().random.nextInt((int)(MaxLeather - MinLeather) + 1));
-            this.dropStack(new ItemStack(Items.LEATHER, leatherAmount));
+                int scaledLeatherAmount = (int) ((MinLeather + this.getWorld().random.nextInt((int) (MaxLeather - MinLeather) + 1)) * (ELvl / 100.0));
+                this.dropStack(new ItemStack(Items.LEATHER, Math.max(0, scaledLeatherAmount)));
+            }
         }
     }
 
@@ -162,30 +200,65 @@ public class CustomCowEntity extends CowEntity {
         if (!(mate instanceof CustomCowEntity))
             return (CustomCowEntity) EntityType.COW.create(serverWorld);
 
-
         CustomCowEntity parent1 = this;
         CustomCowEntity parent2 = (CustomCowEntity) mate;
 
+        // Inherit attributes from parents
         double childMaxHp = (parent1.MaxHp + parent2.MaxHp) / 2;
         double childMinMeat = (parent1.MinMeat + parent2.MinMeat) / 2;
         double childMaxMeat = (parent1.MaxMeat + parent2.MaxMeat) / 2;
         double childMinLeather = (parent1.MinLeather + parent2.MinLeather) / 2;
         double childMaxLeather = (parent1.MaxLeather + parent2.MaxLeather) / 2;
         int childMilkingCooldown = (parent1.milkingCooldown + parent2.milkingCooldown) / 2;
+        double childEnergy = (parent1.ELvl + parent2.ELvl) / 2;
 
         CustomCowEntity child = new CustomCowEntity(ModEntities.CUSTOM_COW, serverWorld);
 
+        // Set inherited and calculated attributes
         child.MaxHp = childMaxHp;
         child.MinMeat = childMinMeat;
         child.MaxMeat = childMaxMeat;
         child.MinLeather = childMinLeather;
         child.MaxLeather = childMaxLeather;
         child.milkingCooldown = childMilkingCooldown;
+        child.ELvl = childEnergy;
+
         child.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(child.MaxHp);
+        child.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED).setBaseValue(child.Speed * (child.ELvl / 100.0));
 
         if (!this.getWorld().isClient)
             updateDescription(child);
 
         return child;
     }
+
+    @Override
+    public void tick() {
+        super.tick();
+
+        // Only perform energy adjustments on the server side
+        if (!this.getWorld().isClient) {
+            // Check if the cow is standing on grass
+            boolean isOnGrass = this.getWorld().getBlockState(this.getBlockPos().down()).isOf(Blocks.GRASS_BLOCK);
+
+            // Adjust energy level based on whether the cow is on grass
+            if (isOnGrass) {
+                ELvl = Math.min(100.0, ELvl + 0.1); // Gain energy (up to max 100)
+            } else {
+                ELvl = Math.max(0.0, ELvl - 0.05); // Lose energy (down to min 0)
+            }
+
+            // If energy reaches 0, kill the cow and drop bones instead of nothing
+            if (ELvl <= 0.0) {
+                this.kill();  // This makes the cow die
+            } else {
+                // Update attributes dynamically if energy is greater than 0
+                this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED).setBaseValue(Speed * (ELvl / 100.0));
+
+                // Optionally, update the description with the new energy level
+                updateDescription(this);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Introduced more energy functionality (drop variance, dynamic energy increase/decrease, and mob death on low energy. Cannot breed if below threshold.

All tested somewhat well. Cows should lose energy at 0.05 per tick if not standing on a grass block. Gain at 0.1 per tick if standing. Cows cannot breed below 30 energy, and die upon reaching 0 energy. Cows drop bones if they die with 0 energy, otherwise drops are scaled based on energy level. 

TODO:
Lower energy cows give a % lower stats to their offspring. 
Make energy increase/decrease system more randomized and potentially slower so cows dont just die every 2 seconds.

Add any suggestions as needed